### PR TITLE
Implement PyPI release workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,171 @@
+name: Release Publish
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-publish-${{ github.event.release.tag_name || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      package_version: ${{ steps.version.outputs.package_version }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Resolve release version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          python - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          pyproject = tomllib.loads(Path("pyproject.toml").read_text())
+          package_version = pyproject["project"]["version"]
+          raw_tag = os.environ["RELEASE_TAG"] if os.environ["EVENT_NAME"] == "release" else os.environ["REF_NAME"]
+          normalized_tag = raw_tag.removeprefix("v")
+
+          if normalized_tag != package_version:
+              raise SystemExit(
+                  f"Tag version {raw_tag!r} does not match pyproject version {package_version!r}"
+              )
+
+          output_path = Path(os.environ["GITHUB_OUTPUT"])
+          with output_path.open("a", encoding="utf-8") as fh:
+              print(f"package_version={package_version}", file=fh)
+          PY
+
+      - name: Build distribution artifacts
+        run: uv build
+
+      - name: Validate distribution artifacts
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          dist = Path("dist")
+          wheels = list(dist.glob("*.whl"))
+          sdists = list(dist.glob("*.tar.gz"))
+
+          if not wheels or not sdists:
+              raise SystemExit(
+                  "Both wheel and source distribution artifacts are required in dist/"
+              )
+
+          print("Built wheel artifacts:", [path.name for path in wheels])
+          print("Built source artifacts:", [path.name for path in sdists])
+          PY
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      already_published: ${{ steps.pypi-status.outputs.already_published }}
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Check whether version already exists on PyPI
+        id: pypi-status
+        env:
+          PACKAGE_NAME: ehr-writeback
+          PACKAGE_VERSION: ${{ needs.build.outputs.package_version }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import urllib.error
+          import urllib.request
+          from pathlib import Path
+
+          package_name = os.environ["PACKAGE_NAME"]
+          package_version = os.environ["PACKAGE_VERSION"]
+          already_published = "false"
+
+          try:
+              with urllib.request.urlopen(
+                  f"https://pypi.org/pypi/{package_name}/json",
+                  timeout=15,
+              ) as response:
+                  payload = json.load(response)
+          except urllib.error.HTTPError as exc:
+              if exc.code != 404:
+                  raise
+          else:
+              if package_version in payload.get("releases", {}):
+                  already_published = "true"
+
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as fh:
+              print(f"already_published={already_published}", file=fh)
+          PY
+
+      - name: Publish package to PyPI
+        if: steps.pypi-status.outputs.already_published != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+      - name: Report existing release
+        if: steps.pypi-status.outputs.already_published == 'true'
+        run: |
+          echo "Version ${{ needs.build.outputs.package_version }} is already present on PyPI."
+          echo "Skipping duplicate publish for this tag."
+
+  verify-install:
+    runs-on: ubuntu-latest
+    needs: [build, publish]
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify install from PyPI
+        env:
+          PACKAGE_VERSION: ${{ needs.build.outputs.package_version }}
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install "ehr-writeback==${PACKAGE_VERSION}"
+          python - <<'PY'
+          import ehr_writeback
+
+          print(getattr(ehr_writeback, "__file__", "ehr_writeback import succeeded"))
+          PY

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ehr-writeback
 
+[![PyPI version](https://img.shields.io/pypi/v/ehr-writeback.svg)](https://pypi.org/project/ehr-writeback/)
+
 Open-source EHR write-back integration framework. Closes the loop from healthcare analytics back to clinical workflow via FHIR.
 
 ## What it does
@@ -36,10 +38,18 @@ Hexagonal (ports-and-adapters) design with two deployment targets:
 
 ## Quick Start
 
+Install from PyPI:
+
+```bash
+pip install ehr-writeback
+```
+
 ```bash
 uv sync            # install dependencies
 uv run pytest      # run unit tests
 ```
+
+To publish a release, create a GitHub release for a `v*` tag whose version matches `pyproject.toml`. The release workflow builds the wheel and source distribution, publishes through PyPI trusted publishing, and verifies `pip install ehr-writeback==<version>` in a clean environment.
 
 ### Run the sepsis risk score example
 


### PR DESCRIPTION
## Summary
- add a release workflow that validates tag/version alignment, builds both sdist and wheel artifacts, publishes via PyPI trusted publishing, and verifies installability
- trigger release publishing from GitHub releases and version tags while skipping duplicate publishes for versions already on PyPI
- add a PyPI badge and install/publish guidance to the README

## Verification
- uv run pytest tests/unit -v --tb=short
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run mypy src/ehr_writeback/core/
- uv build

## Notes
- src/ehr_writeback/pipelines/writeback_pipeline.py:10: error: Cannot find implementation or library stub for module named "dlt"  [import-not-found]
src/ehr_writeback/pipelines/writeback_pipeline.py:11: error: Cannot find implementation or library stub for module named "pyspark.sql"  [import-not-found]
src/ehr_writeback/pipelines/writeback_pipeline.py:16: error: Name "spark" is not defined  [name-defined]
src/ehr_writeback/pipelines/writeback_pipeline.py:17: error: Name "spark" is not defined  [name-defined]
src/ehr_writeback/pipelines/writeback_pipeline.py:26: error: Function is missing a return type annotation  [no-untyped-def]
src/ehr_writeback/pipelines/writeback_pipeline.py:28: error: Name "spark" is not defined  [name-defined]
src/ehr_writeback/pipelines/writeback_pipeline.py:40: error: Function is missing a return type annotation  [no-untyped-def]
src/ehr_writeback/infrastructure/delta_store.py:13: error: Cannot find implementation or library stub for module named "pyspark.sql"  [import-not-found]
src/ehr_writeback/infrastructure/delta_store.py:13: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
src/ehr_writeback/infrastructure/idempotency.py:34: error: Returning Any from function declared to return "bool"  [no-any-return]
src/ehr_writeback/infrastructure/idempotency.py:53: error: Cannot find implementation or library stub for module named "delta.tables"  [import-not-found]
src/ehr_writeback/pipelines/reprocess_dead_letters.py:14: error: Name "dbutils" is not defined  [name-defined]
src/ehr_writeback/pipelines/reprocess_dead_letters.py:22: error: Name "dbutils" is not defined  [name-defined]
src/ehr_writeback/pipelines/reprocess_dead_letters.py:26: error: Name "dbutils" is not defined  [name-defined]
src/ehr_writeback/pipelines/reprocess_dead_letters.py:31: error: Name "spark" is not defined  [name-defined]
src/ehr_writeback/pipelines/reprocess_dead_letters.py:42: error: Function is missing a return type annotation  [no-untyped-def]
src/ehr_writeback/pipelines/reprocess_dead_letters.py:42: note: Use "-> None" if function does not return a value
src/ehr_writeback/pipelines/reprocess_dead_letters.py:54: error: Call to untyped function "reprocess" in typed context  [no-untyped-call]
src/ehr_writeback/adapters/generic/smart_auth.py:44: error: Argument 2 has incompatible type "DHPrivateKey | Ed25519PrivateKey | Ed448PrivateKey | RSAPrivateKey | DSAPrivateKey | EllipticCurvePrivateKey | X25519PrivateKey | X448PrivateKey"; expected "RSAPrivateKey | EllipticCurvePrivateKey | Ed25519PrivateKey | Ed448PrivateKey | PyJWK | str | bytes"  [arg-type]
src/ehr_writeback/adapters/generic/fhir_r4_adapter.py:30: error: Missing type parameters for generic type "dict"  [type-arg]
src/ehr_writeback/adapters/generic/fhir_r4_adapter.py:31: error: Missing type parameters for generic type "dict"  [type-arg]
src/ehr_writeback/adapters/epic/auth.py:48: error: Argument 2 has incompatible type "DHPrivateKey | Ed25519PrivateKey | Ed448PrivateKey | RSAPrivateKey | DSAPrivateKey | EllipticCurvePrivateKey | X25519PrivateKey | X448PrivateKey"; expected "RSAPrivateKey | EllipticCurvePrivateKey | Ed25519PrivateKey | Ed448PrivateKey | PyJWK | str | bytes"  [arg-type]
src/ehr_writeback/adapters/epic/flowsheet_adapter.py:34: error: Missing type parameters for generic type "dict"  [type-arg]
src/ehr_writeback/adapters/epic/fhir_adapter.py:27: error: Missing type parameters for generic type "dict"  [type-arg]
src/ehr_writeback/adapters/epic/fhir_adapter.py:29: error: Missing type parameters for generic type "dict"  [type-arg]
src/ehr_writeback/adapters/cerner/fhir_adapter.py:33: error: Missing type parameters for generic type "dict"  [type-arg]
src/ehr_writeback/adapters/cerner/fhir_adapter.py:34: error: Missing type parameters for generic type "dict"  [type-arg]
Found 25 errors in 10 files (checked 24 source files) still reports pre-existing issues in Databricks and adapter modules outside this change scope